### PR TITLE
Massive performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "url": "https://github.com/Rich-Harris/sourcemap-codec/issues"
   },
   "homepage": "https://github.com/Rich-Harris/sourcemap-codec",
-  "dependencies": {
-    "vlq": "^1.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "codecov.io": "^0.1.6",
     "console-group": "^0.3.3",

--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -20,26 +20,26 @@ export function decode ( mappings: string ): SourceMapMappings {
 	let line: SourceMapLine = [];
 	let segment: number[] = [];
 
-	for (let i = 0, j = 0, shift = 0, value = 0; i < mappings.length; i++) {
+	for ( let i = 0, j = 0, shift = 0, value = 0; i < mappings.length; i++ ) {
 		const c = mappings.charCodeAt(i);
 
-		if (c === 44) { // ","
-			if (segment.length) line.push(<SourceMapSegment>segment);
+		if ( c === 44 ) { // ","
+			if ( segment.length ) line.push( <SourceMapSegment>segment );
 			segment = [];
 			j = 0;
 
-		} else if (c === 59) { // ";"
-			if (segment.length) line.push(<SourceMapSegment>segment);
+		} else if ( c === 59 ) { // ";"
+			if ( segment.length ) line.push( <SourceMapSegment>segment );
 			segment = [];
 			j = 0;
-			decoded.push(line);
+			decoded.push( line );
 			line = [];
 			generatedCodeColumn = 0;
 
 		} else {
 			let integer = charToInteger[c];
-			if (integer === undefined) {
-				throw new Error('Invalid character (' + String.fromCharCode(c) + ')');
+			if ( integer === undefined ) {
+				throw new Error( 'Invalid character (' + String.fromCharCode(c) + ')' );
 			}
 
 			const hasContinuationBit = integer & 32;
@@ -47,7 +47,7 @@ export function decode ( mappings: string ): SourceMapMappings {
 			integer &= 31;
 			value += integer << shift;
 
-			if (hasContinuationBit) {
+			if ( hasContinuationBit ) {
 				shift += 5;
 
 			} else {
@@ -56,25 +56,25 @@ export function decode ( mappings: string ): SourceMapMappings {
 
 				const num = shouldNegate ? -value : value;
 
-				if (j == 0) {
+				if ( j == 0 ) {
 					generatedCodeColumn += num;
-					segment.push(generatedCodeColumn);
+					segment.push( generatedCodeColumn );
 
-				} else if (j === 1) {
+				} else if ( j === 1 ) {
 					sourceFileIndex += num;
-					segment.push(sourceFileIndex);
+					segment.push( sourceFileIndex );
 
-				} else if (j === 2) {
+				} else if ( j === 2 ) {
 					sourceCodeLine += num;
-					segment.push(sourceCodeLine);
+					segment.push( sourceCodeLine );
 
-				} else if (j === 3) {
+				} else if ( j === 3 ) {
 					sourceCodeColumn += num;
-					segment.push(sourceCodeColumn);
+					segment.push( sourceCodeColumn );
 
-				} else if (j === 4) {
+				} else if ( j === 4 ) {
 					nameIndex += num;
-					segment.push(nameIndex);
+					segment.push( nameIndex );
 				}
 
 				j++;
@@ -83,8 +83,8 @@ export function decode ( mappings: string ): SourceMapMappings {
 		}
 	}
 
-	if (segment.length) line.push(<SourceMapSegment>segment);
-	decoded.push(line);
+	if ( segment.length ) line.push( <SourceMapSegment>segment );
+	decoded.push( line );
 
 	return decoded;
 }
@@ -96,55 +96,55 @@ export function encode ( decoded: SourceMapMappings ): string {
 	let nameIndex = 0;           // fifth field
 	let mappings = '';
 
-	for (let i = 0; i < decoded.length; i++) {
+	for ( let i = 0; i < decoded.length; i++ ) {
 		const line = decoded[i];
-		if (i > 0) mappings += ';';
-		if (line.length === 0) continue;
+		if ( i > 0 ) mappings += ';';
+		if ( line.length === 0 ) continue;
 
 		let generatedCodeColumn = 0; // first field
 
 		const lineMappings: string[] = [];
 
-		for (const segment of line) {
-			let segmentMappings = encodeInteger(segment[0] - generatedCodeColumn);
+		for ( const segment of line ) {
+			let segmentMappings = encodeInteger( segment[0] - generatedCodeColumn );
 			generatedCodeColumn = segment[0];
 
-			if (segment.length > 1) {
+			if ( segment.length > 1 ) {
 				segmentMappings +=
-					encodeInteger(segment[1] - sourceFileIndex) +
-					encodeInteger(segment[2] - sourceCodeLine) +
-					encodeInteger(segment[3] - sourceCodeColumn);
+					encodeInteger( segment[1] - sourceFileIndex ) +
+					encodeInteger( segment[2] - sourceCodeLine ) +
+					encodeInteger( segment[3] - sourceCodeColumn );
 
 				sourceFileIndex = segment[1];
 				sourceCodeLine = segment[2];
 				sourceCodeColumn = segment[3];
 			}
 
-			if (segment.length === 5) {
-				segmentMappings += encodeInteger(segment[4] - nameIndex);
+			if ( segment.length === 5 ) {
+				segmentMappings += encodeInteger( segment[4] - nameIndex );
 				nameIndex = segment[4];
 			}
 
-			lineMappings.push(segmentMappings);
+			lineMappings.push( segmentMappings );
 		}
 
-		mappings += lineMappings.join(',');
+		mappings += lineMappings.join( ',' );
 	}
 
 	return mappings;
 }
 
-function encodeInteger(num: number): string {
+function encodeInteger( num: number ): string {
 	var result = '';
 	num = num < 0 ? (-num << 1) | 1 : num << 1;
 	do {
 		var clamped = num & 31;
 		num >>= 5;
-		if (num > 0) {
+		if ( num > 0 ) {
 			clamped |= 32;
 		}
 		result += chars[clamped];
-	} while (num > 0);
+	} while ( num > 0 );
 
 	return result;
 }


### PR DESCRIPTION
Rewrote decoding with a streaming version that processes the mapping character by character (without creating intermediate arrays). On a big source map sample (GL JS), it's 2.6x faster than the current implementation (down from 59ms to 22ms), with smaller memory footprint.

Stand by while I'm working on optimizing encoding as well.

The only caveat is that I'd need to remove the `vlq` dependency to be able to inline it optimally.

@Rich-Harris are you OK with this direction?