### PR TITLE
Optimized runtime speed and updated development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 coverage
 package-lock.json
+.idea

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
   "devDependencies": {
     "codecov.io": "^0.1.6",
     "console-group": "^0.3.3",
-    "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint": "^5.6.0",
+    "eslint-plugin-import": "^2.14.0",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
-    "remap-istanbul": "^0.9.5",
-    "rollup": "^0.54.0",
-    "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-typescript": "^0.8.1",
-    "typescript": "^2.7.1"
+    "mocha": "^5.2.0",
+    "remap-istanbul": "^0.12.0",
+    "rollup": "^0.66.0",
+    "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-typescript": "^1.0.0",
+    "typescript": "^3.0.3"
   },
   "files": [
     "dist/*.js",

--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -23,16 +23,16 @@ export function decode(mappings: string): SourceMapMappings {
 	let line: SourceMapLine = [];
 	let segment: number[] = [];
 
-	for (let i = 0, j = 0, shift = 0, value = 0; i < mappings.length; i++) {
+	for (let i = 0, j = 0, shift = 0, value = 0, len = mappings.length; i < len; i++) {
 		const c = mappings.charCodeAt(i);
 
 		if (c === 44) { // ","
-			if (segment.length) line.push(<SourceMapSegment>segment);
+			if (segment.length) line.push(new Int8Array(segment) as any);
 			segment = [];
 			j = 0;
 
 		} else if (c === 59) { // ";"
-			if (segment.length) line.push(<SourceMapSegment>segment);
+			if (segment.length) line.push(new Int8Array(segment) as any);
 			segment = [];
 			j = 0;
 			decoded.push(line);
@@ -85,7 +85,7 @@ export function decode(mappings: string): SourceMapMappings {
 		}
 	}
 
-	if (segment.length) line.push(<SourceMapSegment>segment);
+	if (segment.length) line.push(new Int8Array(segment) as any);
 	decoded.push(line);
 
 	return decoded;


### PR DESCRIPTION
Hi!

I was looking at Rollup build performance and found this module consumes a lot of memory and CPU time. I couldn't optimize the memory consumption and only changes that had any impact on performance are on this PR.

1 - I cached `mappings.length` to `len` variable (.5s diff)
2 - I changed type of array to Int8Array which had biggest impact (4-5s diff)

Total time of rollup build in our application:
```
Before:
67.107s
67.535s
68.158s
68.301s
70.307s

After:
63.797s
65.111s
65.029s
65.675s
63.914s
```