### PR TITLE
Include dist/*.js.map files into npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "dist/*.js",
+    "dist/*.js.map",
     "dist/**/*.d.ts",
     "README.md"
   ]


### PR DESCRIPTION
Fix #73 

The sourcemaps are generated during the build, but the `files` property in `package.json` doesn't include them, so they are not published to `npm`. This results in missing sourcemaps when users install the package from `npm`.