### PR TITLE
Increased segment value range from Int16 to Int32

### DIFF
--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -27,12 +27,12 @@ export function decode(mappings: string): SourceMapMappings {
 		const c = mappings.charCodeAt(i);
 
 		if (c === 44) { // ","
-			if (segment.length) line.push(new Int16Array(segment) as any);
+			if (segment.length) line.push(new Int32Array(segment) as any);
 			segment = [];
 			j = 0;
 
 		} else if (c === 59) { // ";"
-			if (segment.length) line.push(new Int16Array(segment) as any);
+			if (segment.length) line.push(new Int32Array(segment) as any);
 			segment = [];
 			j = 0;
 			decoded.push(line);
@@ -85,7 +85,7 @@ export function decode(mappings: string): SourceMapMappings {
 		}
 	}
 
-	if (segment.length) line.push(new Int16Array(segment) as any);
+	if (segment.length) line.push(new Int32Array(segment) as any);
 	decoded.push(line);
 
 	return decoded;

--- a/test/test.js
+++ b/test/test.js
@@ -133,6 +133,18 @@ describe('sourcemap-codec', () => {
 					[282, 0, 13, 34]
 				]
 			]
+		},
+		{
+			// Make sure Int16 isn't being used
+			encoded: "gw+BAAAA,w+BAAAA,w+BAAAA,w+BAAAA",
+			decoded: [
+				[
+					[32000,0,0,0,0],
+					[33000,0,0,0,0],
+					[34000,0,0,0,0],
+					[35000,0,0,0,0]
+				]
+			]
 		}
 	];
 


### PR DESCRIPTION
When using rollup with uglify the resulting code may have lines longer than 32767 (Int16) characters, which when decoded can cause int overflow and negative columns due to #74 & #75 changes

![image](https://user-images.githubusercontent.com/1122555/47342201-cead0f80-d6ab-11e8-9a65-24504eb92d94.png)