### PR TITLE
Handle overflow cases

### DIFF
--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -54,28 +54,31 @@ export function decode(mappings: string): SourceMapMappings {
 				shift += 5;
 			} else {
 				const shouldNegate = value & 1;
-				value >>= 1;
+				value >>>= 1;
 
-				const num = shouldNegate ? -value : value;
+				if (shouldNegate) {
+					value = -value;
+					if (value === 0) value = -0x80000000;
+				}
 
 				if (j == 0) {
-					generatedCodeColumn += num;
+					generatedCodeColumn += value;
 					segment.push(generatedCodeColumn);
 
 				} else if (j === 1) {
-					sourceFileIndex += num;
+					sourceFileIndex += value;
 					segment.push(sourceFileIndex);
 
 				} else if (j === 2) {
-					sourceCodeLine += num;
+					sourceCodeLine += value;
 					segment.push(sourceCodeLine);
 
 				} else if (j === 3) {
-					sourceCodeColumn += num;
+					sourceCodeColumn += value;
 					segment.push(sourceCodeColumn);
 
 				} else if (j === 4) {
-					nameIndex += num;
+					nameIndex += value;
 					segment.push(nameIndex);
 				}
 
@@ -141,7 +144,7 @@ function encodeInteger(num: number): string {
 	num = num < 0 ? (-num << 1) | 1 : num << 1;
 	do {
 		var clamped = num & 31;
-		num >>= 5;
+		num >>>= 5;
 		if (num > 0) {
 			clamped |= 32;
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -145,6 +145,24 @@ describe('sourcemap-codec', () => {
 					[35000,0,0,0,0]
 				]
 			]
+		},
+		{
+			// Handle largest 32bit int
+			encoded: "+/////D",
+			decoded: [
+				[
+					[2147483647]
+				]
+			]
+		},
+		{
+			// Handle smallest 32bit int
+			encoded: "B",
+			decoded: [
+				[
+					[-2147483648]
+				]
+			]
 		}
 	];
 


### PR DESCRIPTION
There were overflow cases hidden in the encode and decode:

1. Encoding
   - Any number with the 31st bit set would be incorrect, because it used `>>` instead of `>>>`. So the 31st bit would be set to the 32nd (sign bit, making it negative). Then when we try to encode the number, we would that it's `num < 0` after the first iteration.
2. Decoding
   - The encoded representation of -2147483648 (smallest 32bit signed int) would return -0
   - Any number with the 31st bit set would return the opposite sign, because it used `>>` instead of `>>>`.