### PR TITLE
Use regular arrays instead of Int32Array

### DIFF
--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -27,12 +27,12 @@ export function decode(mappings: string): SourceMapMappings {
 		const c = mappings.charCodeAt(i);
 
 		if (c === 44) { // ","
-			if (segment.length) line.push(new Int32Array(segment) as any);
+			if (segment.length) line.push(segment as SourceMapSegment);
 			segment = [];
 			j = 0;
 
 		} else if (c === 59) { // ";"
-			if (segment.length) line.push(new Int32Array(segment) as any);
+			if (segment.length) line.push(segment as SourceMapSegment);
 			segment = [];
 			j = 0;
 			decoded.push(line);
@@ -88,7 +88,7 @@ export function decode(mappings: string): SourceMapMappings {
 		}
 	}
 
-	if (segment.length) line.push(new Int32Array(segment) as any);
+	if (segment.length) line.push(segment as SourceMapSegment);
 	decoded.push(line);
 
 	return decoded;

--- a/test/test.js
+++ b/test/test.js
@@ -175,10 +175,7 @@ describe('sourcemap-codec', () => {
 	describe('decode()', () => {
 		tests.forEach((test, i) => {
 			it('decodes sample ' + i, () => {
-				const expected = test.decoded.map(line => {
-					return line.map(segment => new Int32Array(segment));
-				});
-				assert.deepEqual(decode(test.encoded), expected);
+				assert.deepEqual(decode(test.encoded), test.decoded);
 			});
 		});
 	});


### PR DESCRIPTION
This gives ~10x speed up. This makes sense because you're creating a duplicate array (the typed array) which has to allocate, iterate the segment, and clamp that value into the typed array. For a 4-pack segment, that's an extra 32bytes of memory allocation (plus the typed array's overhead).

Browser: https://jsbench.github.io/#1c14a94a45bf9675ce4612026187c256

Or, if you want to test on multiple node versions, try copying https://gist.github.com/jridgewell/0e89c5ea9428071cc4f9486c9ca82761 into the root directory.

```bash
$ npx node@12 benchmark.js
v12.5.0
decode (current) x 2,863 ops/sec ±5.96% (62 runs sampled)
decode (proposal) x 8,514 ops/sec ±4.78% (65 runs sampled)
Fastest is decode (proposal)

$ npx node@10 benchmark.js
v10.16.0
decode (current) x 706 ops/sec ±8.63% (62 runs sampled)
decode (proposal) x 8,345 ops/sec ±6.41% (53 runs sampled)
Fastest is decode (proposal)

$ npx node@8 benchmark.js
v8.16.0
decode (current) x 2,440 ops/sec ±7.05% (64 runs sampled)
decode (proposal) x 7,037 ops/sec ±3.70% (55 runs sampled)
Fastest is decode (proposal)

$ npx node@6 benchmark.js
v6.17.1
decode (current) x 588 ops/sec ±8.61% (51 runs sampled)
decode (proposal) x 5,848 ops/sec ±7.55% (56 runs sampled)
Fastest is decode (proposal)
```