### PR TITLE
Optimize decode

### DIFF
--- a/src/sourcemap-codec.ts
+++ b/src/sourcemap-codec.ts
@@ -13,31 +13,30 @@ for (let i = 0; i < chars.length; i++) {
 }
 
 export function decode(mappings: string): SourceMapMappings {
-	let generatedCodeColumn = 0; // first field
-	let sourceFileIndex = 0;     // second field
-	let sourceCodeLine = 0;      // third field
-	let sourceCodeColumn = 0;    // fourth field
-	let nameIndex = 0;           // fifth field
-
 	const decoded: SourceMapMappings = [];
 	let line: SourceMapLine = [];
-	let segment: number[] = [];
+	const segment: SourceMapSegment = [
+		0, // generated code column
+		0, // source file index
+		0, // source code line
+		0, // source code column
+		0, // name index
+	];
 
-	for (let i = 0, j = 0, shift = 0, value = 0, len = mappings.length; i < len; i++) {
+	let j = 0;
+	for (let i = 0, shift = 0, value = 0; i < mappings.length; i++) {
 		const c = mappings.charCodeAt(i);
 
 		if (c === 44) { // ","
-			if (segment.length) line.push(segment as SourceMapSegment);
-			segment = [];
+			segmentify(line, segment, j);
 			j = 0;
 
 		} else if (c === 59) { // ";"
-			if (segment.length) line.push(segment as SourceMapSegment);
-			segment = [];
+			segmentify(line, segment, j);
 			j = 0;
 			decoded.push(line);
 			line = [];
-			generatedCodeColumn = 0;
+			segment[0] = 0;
 
 		} else {
 			let integer = charToInteger[c];
@@ -61,37 +60,27 @@ export function decode(mappings: string): SourceMapMappings {
 					if (value === 0) value = -0x80000000;
 				}
 
-				if (j == 0) {
-					generatedCodeColumn += value;
-					segment.push(generatedCodeColumn);
-
-				} else if (j === 1) {
-					sourceFileIndex += value;
-					segment.push(sourceFileIndex);
-
-				} else if (j === 2) {
-					sourceCodeLine += value;
-					segment.push(sourceCodeLine);
-
-				} else if (j === 3) {
-					sourceCodeColumn += value;
-					segment.push(sourceCodeColumn);
-
-				} else if (j === 4) {
-					nameIndex += value;
-					segment.push(nameIndex);
-				}
-
+				segment[j] += value;
 				j++;
 				value = shift = 0; // reset
 			}
 		}
 	}
 
-	if (segment.length) line.push(segment as SourceMapSegment);
+	segmentify(line, segment, j);
 	decoded.push(line);
 
 	return decoded;
+}
+
+function segmentify(line: SourceMapSegment[], segment: SourceMapSegment, j: number) {
+	// This looks ugly, but we're creating specialized arrays with a specific
+	// length. This is much faster than creating a new array (which v8 expands to a
+	// capacity of 17 after pushing the first item), or slicing out a subarray
+	// (which is slow).
+	if (j === 1) line.push([segment[0]]);
+	else if (j === 4) line.push([segment[0], segment[1], segment[2], segment[3]]);
+	else if (j === 5) line.push([segment[0], segment[1], segment[2], segment[3], segment[4]]);
 }
 
 export function encode(decoded: SourceMapMappings): string {


### PR DESCRIPTION
Thinking of https://github.com/Rich-Harris/sourcemap-codec/pull/74, I decided to see what v8 would use as the capacity of the segment arrays. Surprisingly, after pushing the first element into a new array, the array's internal capacity expands to 17 elements! For us, that's ~68 wasted bytes!

<details>

<summary>Debug printing an array's capacity</summary>

```text
$ ~/.jsvu/v8-debug --allow-natives-syntax
V8 version 7.7.185
d8> segment = []
[]

d8> %DebugPrint(segment)
DebugPrint: 0x34aee65cb2b9: [JSArray]
 - map: 0x34ae80c82e89 <Map(PACKED_SMI_ELEMENTS)> [FastProperties]
 - prototype: 0x34ae41b11859 <JSArray[0]>
 - elements: 0x34ae57ec0c21 <FixedArray[0]> [PACKED_SMI_ELEMENTS]
 - length: 0
 - properties: 0x34ae57ec0c21 <FixedArray[0]> {
    #length: 0x34ae489801a9 <AccessorInfo> (const accessor descriptor)
 }
 ...

d8> segment.push(0)
1

d8> %DebugPrint(segment)
DebugPrint: 0x34aee65cb2b9: [JSArray]
 - map: 0x34ae80c82e89 <Map(PACKED_SMI_ELEMENTS)> [FastProperties]
 - prototype: 0x34ae41b11859 <JSArray[0]>
 - elements: 0x34aee65cdd29 <FixedArray[17]> [PACKED_SMI_ELEMENTS]
 - length: 1
 - properties: 0x34ae57ec0c21 <FixedArray[0]> {
    #length: 0x34ae489801a9 <AccessorInfo> (const accessor descriptor)
 }
 - elements: 0x34aee65cdd29 <FixedArray[17]> {
           0: 0
        1-16: 0x34ae57ec05b1 <the_hole>
 }
 ...
```

</details>

If we instead create fresh array literals, we get arrays with no excess internal capacity.

<details>

<summary>Pushing array literal constructed from an array elements</summary>

```text
V8 version 7.7.185
d8> segment = [1, 2, 3, 4, 5]
[1, 2, 3, 4, 5]

d8> %DebugPrint([ segment[0] ])
DebugPrint: 0x482e084d851: [JSArray]
 - map: 0x04824efc2e89 <Map(PACKED_SMI_ELEMENTS)> [FastProperties]
 - prototype: 0x04822fb51859 <JSArray[0]>
 - elements: 0x0482e084d839 <FixedArray[1]> [PACKED_SMI_ELEMENTS]
 - length: 1
 - properties: 0x04821a780c21 <FixedArray[0]> {
    #length: 0x0482375001a9 <AccessorInfo> (const accessor descriptor)
 }
 - elements: 0x0482e084d839 <FixedArray[1]> {
           0: 1
 }

d8> %DebugPrint([ segment[0], segment[1], segment[2], segment[3] ])
DebugPrint: 0x482e084daa1: [JSArray]
 - map: 0x04824efc2e89 <Map(PACKED_SMI_ELEMENTS)> [FastProperties]
 - prototype: 0x04822fb51859 <JSArray[0]>
 - elements: 0x0482e084da71 <FixedArray[4]> [PACKED_SMI_ELEMENTS]
 - length: 4
 - properties: 0x04821a780c21 <FixedArray[0]> {
    #length: 0x0482375001a9 <AccessorInfo> (const accessor descriptor)
 }
 - elements: 0x0482e084da71 <FixedArray[4]> {
           0: 1
           1: 2
           2: 3
           3: 4
 }
```

</details>

- - -

This gets us a [~30% boost in performance](https://gist.github.com/jridgewell/0e89c5ea9428071cc4f9486c9ca82761) (and there's not a good framework for memory benchmarks, but I imagine it's massive):

```text
$ npx node@12 benchmark.js
v12.6.0
decode (v1.4.6) x 19,302 ops/sec ±1.02% (91 runs sampled)
decode (proposal) x 25,188 ops/sec ±3.22% (92 runs sampled)
Fastest is decode (proposal)

$ npx node@10 benchmark.js
v10.16.0
decode (v1.4.6) x 18,275 ops/sec ±5.84% (82 runs sampled)
decode (proposal) x 24,739 ops/sec ±14.43% (74 runs sampled)
Fastest is decode (proposal)

$ npx node@8 benchmark.js
v8.16.0
decode (v1.4.6) x 14,467 ops/sec ±2.10% (86 runs sampled)
decode (proposal) x 17,241 ops/sec ±1.32% (91 runs sampled)
Fastest is decode (proposal)

$ npx node@6 benchmark.js
v6.17.1
decode (v1.4.6) x 13,711 ops/sec ±1.70% (92 runs sampled)
decode (proposal) x 20,953 ops/sec ±1.33% (91 runs sampled)
Fastest is decode (proposal)
```