### PR TITLE
Add native ESM entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,15 @@
   "main": "dist/sourcemap-codec.umd.js",
   "module": "dist/sourcemap-codec.es.js",
   "types": "dist/types/sourcemap-codec.d.ts",
+  "exports": {
+    ".": {
+      "browser": "./dist/sourcemap-codec.umd.js",
+      "import": "./dist/sourcemap-codec.mjs",
+      "require": "./dist/sourcemap-codec.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
+  },
   "scripts": {
     "test": "mocha",
     "build": "rm -rf dist && rollup -c && tsc",
@@ -30,7 +39,6 @@
     "url": "https://github.com/Rich-Harris/sourcemap-codec/issues"
   },
   "homepage": "https://github.com/Rich-Harris/sourcemap-codec",
-  "dependencies": {},
   "devDependencies": {
     "codecov.io": "^0.1.6",
     "console-group": "^0.3.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,5 +21,10 @@ export default {
 		file: pkg.module,
 		format: 'es',
 		sourcemap: true
+	},
+	{
+		file: pkg.exports['.'].import,
+		format: 'es',
+		sourcemap: true
 	}]
 };


### PR DESCRIPTION
This PR adds an ESM entry point so that this library can be used with ES modules natively in node.

Explanation:

```js
"exports": {
  // Main/default entry point
  ".": {
    "browser": "./dist/sourcemap-codec.umd.js",
    // Must be `.mjs` because our `package.json` doesn't include `"type": "module"`
    "import": "./dist/sourcemap-codec.mjs",
    // CommonJS entry point
    "require": "./dist/sourcemap-codec.umd.js"
  },
  // If any module wants to import `sourcemap-codec/package.json` for some reason
  // (grabbing package.version or something)
  "./package.json": "./package.json",
  // Old-style deep imports, like `require("sourcemap-codec/dist/sourcemap-codec.umd.js")`
  "./": "./"
},
```

Verified both CommonJS and ESM entries in node `12.18.0` locally.

Fixes #81 .